### PR TITLE
[autodoc] adding python autodoc of c++ wrapped python module

### DIFF
--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -15,11 +15,20 @@ Contents
    changelog
    about
 
-Reference manual
-----------------
+C++ reference manual
+--------------------
 
 .. toctree::
    :maxdepth: 5
 
    cpp2rst_generated/app4triqs/toto
    cpp2rst_generated/app4triqs/chain
+
+Python reference manual
+-----------------------
+
+.. autoclass:: app4triqs.toto_module.toto
+   :members:
+
+.. autofunction:: app4triqs.toto_module.chain
+      


### PR DESCRIPTION
Dear all,

This is a minimal example of auto doc on the wrapped c++ module in python. I have not been able to test this yet since I do not have triqs/unstable (i.e. 2.2.0) built on my system. This should generate the sphinx autodoc for both the wrapped class and the wrapped function.

Best regards,
Hugo