### PR TITLE
Use ENVIRONMENT_MODIFICATION instead of ENVIRONMENT for PYTHONPATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@
 #
 # ##############################################################################
 
-cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
 cmake_policy(VERSION ${CMAKE_VERSION})
 
 # ############

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -12,7 +12,6 @@ foreach(test ${all_tests})
   get_filename_component(test_dir ${test} DIRECTORY)
   add_test(NAME Py_${test_name} COMMAND ${TRIQS_PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${test_dir}/${test_name}.py WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${test_dir})
   set_property(TEST Py_${test_name} APPEND PROPERTY ENVIRONMENT_MODIFICATION
-    "PYTHONPATH=path_list_prepend:${PROJECT_BINARY_DIR}/python"
-    "PYTHONPATH=path_list_prepend:$ENV{PYTHONPATH}")
+    "PYTHONPATH=path_list_prepend:${PROJECT_BINARY_DIR}/python")
   set_property(TEST Py_${test_name} APPEND PROPERTY ENVIRONMENT ${SANITIZER_RT_PRELOAD})
 endforeach()

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -11,5 +11,8 @@ foreach(test ${all_tests})
   get_filename_component(test_name ${test} NAME_WE)
   get_filename_component(test_dir ${test} DIRECTORY)
   add_test(NAME Py_${test_name} COMMAND ${TRIQS_PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${test_dir}/${test_name}.py WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${test_dir})
-  set_property(TEST Py_${test_name} APPEND PROPERTY ENVIRONMENT PYTHONPATH=${PROJECT_BINARY_DIR}/python:$ENV{PYTHONPATH} ${SANITIZER_RT_PRELOAD})
+  set_property(TEST Py_${test_name} APPEND PROPERTY ENVIRONMENT_MODIFICATION
+    "PYTHONPATH=path_list_prepend:${PROJECT_BINARY_DIR}/python"
+    "PYTHONPATH=path_list_prepend:$ENV{PYTHONPATH}")
+  set_property(TEST Py_${test_name} APPEND PROPERTY ENVIRONMENT ${SANITIZER_RT_PRELOAD})
 endforeach()


### PR DESCRIPTION
Currently the Python tests have the property setting
```cmake
ENVIRONMENT PYTHONPATH=${PROJECT_BINARY_DIR}/python:$ENV{PYTHONPATH}
```
With this the value of `PYTHONPATH` that will be used during CTest is frozen at configure time.

To make tests dynamically modify the value of `PYTHONPATH` it is better to use [`ENVIRONMENT_MODIFICATION`](https://cmake.org/cmake/help/v3.22/prop_test/ENVIRONMENT_MODIFICATION.html) (introduced in CMake 3.22).