### PR TITLE
Adhere to c2py arithmetic tuple pair api change (drop c2py::triplet)

### DIFF
--- a/python/app4triqs/module.cpp
+++ b/python/app4triqs/module.cpp
@@ -4,6 +4,6 @@
 
 using namespace std::string_literals;
 using app4triqs::toto;
-template <> struct c2py::arithmetic<toto, c2py::OpName::Add> : std::tuple<triplet<toto, toto, toto>> {};
+template <> struct c2py::arithmetic<toto, c2py::OpName::Add> : std::tuple<std::pair<toto, toto>> {};
 
 #include "module.wrap.cxx"


### PR DESCRIPTION
Dear @Wentzell ,

Here is a micro fix for `app4triqs/clair` to be compatible with the recent drop of the `c2py::triplet` type.

Please consider merging.

MfG / Hugo