### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+**/*.cxx linguist-generated
+**/*.hxx linguist-generated
+**/*.h5 linguist-generated
+**/*.dat linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-**/*.cxx linguist-generated
-**/*.hxx linguist-generated
-**/*.h5 linguist-generated
-**/*.dat linguist-generated
+*.cxx linguist-generated
+*.hxx linguist-generated
+*.h5 linguist-generated
+*.dat linguist-generated


### PR DESCRIPTION
This PR adds a .gitattributes file which marks certain file types as "generated" and should make it so changes to those files are not counted in the contributions map. For now these are `.h5`, `.dat`, `.cxx` and `.hxx` files. 

We add this in particular because the clair tool generates cxx and hxx files, which can result in large diffs/contributions each time the python bindings are updated.  