### PR TITLE
[jenkins] migration to new k8s-based system

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,0 +1,5 @@
+# See ../triqs/packaging for other options
+FROM flatironinstitute/triqs:unstable-ubuntu-clang
+
+# Install here missing dependencies, e.g.
+# RUN apt-get update && apt-get install -y python3-skimage

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -4,7 +4,7 @@ def projectName = "app4triqs" /* set to app/repo name */
 def documentationPlatform = "ubuntu-clang"
 /* Platforms that regenerate the Python bindings via clair-c2py.
    All others use the default (OFF) from c2py. */
-def regenPlatform = "ubuntu-clang"
+def regenPlatforms = ["ubuntu-clang"]
 /* depend on triqs upstream branch/project */
 def triqsBranch = env.BRANCH_NAME == "jenkins" ? "jenkins" : "unstable"
 def triqsProject = '/CCQ/TRIQS/triqs/' + triqsBranch.replaceAll('/', '%2F')
@@ -27,12 +27,17 @@ def mounts = ["triqs": installBase]
 
 def runBuild = { String platform, String prefix, List<String> envs ->
   def macos = platform.startsWith("macos-")
-  def regen = platform == regenPlatform
+  def regen = regenPlatforms.contains(platform)
   def buildDir = "$WORKSPACE_TMP/build"
   /* install real branches in a fixed predictable place so apps can find them */
   def installDir = keepInstall ? "$prefix/install/$JOB_NAME/$platform" : "$WORKSPACE_TMP/install"
   def triqsDir = "$prefix/install$triqsProject/${platform}"
-  def pythonVer = sh(returnStdout: true, script: """python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")'""").trim()
+  envs += [
+    "OPENBLAS_NUM_THREADS=1",
+    "MKL_NUM_THREADS=1"]
+  /* the triqs venv on macOS is built from the brew python, which may differ from the system python3 */
+  def python3 = macos ? "${env.BREW}/bin/python3" : "python3"
+  def pythonVer = sh(returnStdout: true, script: """$python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")'""").trim()
   def triqsPy = "$triqsDir/lib/python$pythonVer"
   envs << "PYTHONPATH=$triqsPy/dist-packages:$triqsPy/site-packages"
   if (macos) {
@@ -62,7 +67,7 @@ def runBuild = { String platform, String prefix, List<String> envs ->
       pip3 install -U -r $WORKSPACE/requirements.txt
     """
   } else {
-    def path = sh(returnStdout: true, script: 'echo $PATH')
+    def path = sh(returnStdout: true, script: 'echo $PATH').trim()
     envs << "PATH=$triqsDir/bin:$path"
   }
   withEnv(envs) {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,0 +1,193 @@
+def projectName = "app4triqs" /* set to app/repo name */
+
+/* which platform to build documentation on */
+def documentationPlatform = "ubuntu-clang"
+/* Platforms that regenerate the Python bindings via clair-c2py.
+   All others use the default (OFF) from c2py. */
+def regenPlatform = "ubuntu-clang"
+/* depend on triqs upstream branch/project */
+def triqsBranch = env.BRANCH_NAME == "jenkins" ? "jenkins" : "unstable"
+def triqsProject = '/CCQ/TRIQS/triqs/' + triqsBranch.replaceAll('/', '%2F')
+/* whether to keep and publish the results */
+def keepInstall = false // disabled on jenkins-new: !env.BRANCH_NAME.startsWith("PR-")
+
+properties([
+  disableConcurrentBuilds(),
+  buildDiscarder(logRotator(numToKeepStr: '10', daysToKeepStr: '30')),
+  pipelineTriggers(keepInstall ? [
+    upstream(
+      threshold: 'SUCCESS',
+      upstreamProjects: triqsProject
+    )
+  ] : [])
+])
+
+def installBase = "/mnt/triqs"
+def mounts = ["triqs": installBase]
+
+def runBuild = { String platform, String prefix, List<String> envs ->
+  def macos = platform.startsWith("macos-")
+  def regen = platform == regenPlatform
+  def buildDir = "$WORKSPACE_TMP/build"
+  /* install real branches in a fixed predictable place so apps can find them */
+  def installDir = keepInstall ? "$prefix/install/$JOB_NAME/$platform" : "$WORKSPACE_TMP/install"
+  def triqsDir = "$prefix/install$triqsProject/${platform}"
+  def pythonVer = sh(returnStdout: true, script: """python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")'""").trim()
+  def triqsPy = "$triqsDir/lib/python$pythonVer"
+  envs << "PYTHONPATH=$triqsPy/dist-packages:$triqsPy/site-packages"
+  if (macos) {
+    dir(installDir) {
+      deleteDir()
+    }
+    checkout scm
+    dir(buildDir) {
+      deleteDir()
+    }
+    def brew = env.BREW
+    def hdf5 = "$brew/opt/hdf5"
+    def venv = triqsDir
+    envs += [
+      "PATH=$venv/bin:$brew/bin:/usr/bin:/bin:/usr/sbin",
+      "HDF5_ROOT=$hdf5",
+      "C_INCLUDE_PATH=$hdf5/include:$brew/include",
+      "CPLUS_INCLUDE_PATH=$venv/include:$hdf5/include:$brew/include",
+      "LIBRARY_PATH=$venv/lib:$hdf5/lib:$brew/lib",
+      "DYLD_LIBRARY_PATH=$venv/lib:$hdf5/lib:$brew/lib",
+      "CMAKE_PREFIX_PATH=$venv/lib/cmake/triqs",
+      "VIRTUAL_ENV=$venv",
+      "OMP_NUM_THREADS=${env.PARALLEL}"]
+    /* note: this is installing into the parent (triqs) venv (install dir), which is thus shared among apps and so not be completely safe */
+    sh """#!/bin/sh -ex
+      source $venv/bin/activate
+      pip3 install -U -r $WORKSPACE/requirements.txt
+    """
+  } else {
+    def path = sh(returnStdout: true, script: 'echo $PATH')
+    envs << "PATH=$triqsDir/bin:$path"
+  }
+  withEnv(envs) {
+    def args = regen ? '-DUpdate_Python_Bindings=ON' : ''
+    if (platform == documentationPlatform)
+      args += ' -DBuild_Documentation=ON'
+    else if (platform == "sanitize")
+      args += ' -DASAN=ON -DUBSAN=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo'
+    dir(buildDir) {
+      sh """#!/bin/sh -ex
+        cmake $WORKSPACE -DCMAKE_INSTALL_PREFIX=$installDir -DTRIQS_ROOT=$triqsDir $args
+        make -j\$PARALLEL || make -j1 VERBOSE=1
+      """
+      catchError(buildResult: 'UNSTABLE', stageResult: 'UNSTABLE') {
+        try {
+          sh "make test CTEST_OUTPUT_ON_FAILURE=1"
+        } catch (exc) {
+          archiveArtifacts(artifacts: 'Testing/Temporary/LastTest.log')
+          throw exc
+        }
+      }
+      sh "make install"
+    }
+  }
+}
+
+/* map of all builds to run, populated below */
+def platforms = [:]
+
+/****************** linux builds (in docker) */
+/* Each platform must have a corresponding Dockerfile.PLATFORM in triqs/packaging */
+def dockerPlatforms = ["ubuntu-clang", "ubuntu-gcc", "ubuntu-intel", "sanitize"]
+for (int i = 0; i < dockerPlatforms.size(); i++) {
+  def platform = dockerPlatforms[i]
+  platforms[platform] = { ->
+    stage(platform) {
+      timeout(time: 1, unit: 'HOURS') {
+        buildPod(tag: platform,
+          context: 'jenkins',
+          dockerfile: "Dockerfile.$platform",
+          devShm: true,
+          mounts: mounts,
+          prep: {
+            /* construct a Dockerfile for this base */
+            sh """
+              ( echo "FROM $REGISTRY_PREFIX${triqsProject.toLowerCase()}:$platform" ; sed '0,/^FROM /d' jenkins/Dockerfile ) > jenkins/Dockerfile.$platform
+            """
+          }) {
+          runBuild(platform, installBase, [])
+        }
+      }
+    }
+  }
+}
+
+/****************** macos builds (on host) */
+def macosPlatforms = [
+  ["gcc", ['CC=gcc-15', 'CXX=g++-15', 'FC=gfortran-15']],
+  ["clang", ['CC=$BREW/opt/llvm/bin/clang', 'CXX=$BREW/opt/llvm/bin/clang++', 'FC=gfortran-15', 'CXXFLAGS=-I$BREW/opt/llvm/include', 'LDFLAGS=-L$BREW/opt/llvm/lib']]
+]
+for (int i = 0; i < macosPlatforms.size(); i++) {
+  def platformEnv = macosPlatforms[i]
+  def platform = platformEnv[0]
+  platforms["macos-$platform"] = { -> node('macos && m1') {
+    stage("macos-$platform") { timeout(time: 1, unit: 'HOURS') {
+      runBuild("macos-$platform", env.HOME, platformEnv[1].collect { it.replace('\$BREW', env.BREW) })
+    } }
+  } }
+}
+
+/****************** wrap-up */
+catchError {
+  parallel platforms
+
+  if (keepInstall) {
+    /* Publish results */
+    stage("publish") {
+      timeout(time: 10, unit: 'MINUTES') {
+        runPod(tag: documentationPlatform,
+          mounts: mounts) {
+          def commit = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
+          def release = env.BRANCH_NAME == "master" || env.BRANCH_NAME == "unstable" || sh(returnStdout: true, script: "git describe --exact-match HEAD || true").trim()
+          lock(resource: 'triqs_publish') {
+            /* Update documention on gh-pages branch */
+            dir("$WORKSPACE_TMP/gh-pages") {
+              def subdir = "$projectName/${env.BRANCH_NAME}"
+              def ghp = scmGit(branches: [[name: 'refs/heads/master']],
+                userRemoteConfigs: [[credentialsId: 'github-jenkins', url: 'https://github.com/TRIQS/TRIQS.github.io.git']])
+              checkout scm: ghp, changelog: false
+              sh "rm -rf ${subdir}"
+              def installDir = "$installBase/install/$JOB_NAME/$documentationPlatform"
+              sh """#!/bin/bash -ex
+                base=$installDir/share/doc
+                dir="$projectName"
+                [[ -d \$base/triqs_\$dir ]] && dir=triqs_\$dir || [[ -d \$base/\$dir ]]
+                cp -r \$base/\$dir ${subdir}
+                git add -A ${subdir}
+                GIT_COMMITTER_EMAIL="jenkins@flatironinstitute.org" GIT_COMMITTER_NAME="Flatiron Jenkins" git commit --author='Flatiron Jenkins <jenkins@flatironinstitute.org>' --allow-empty -m 'Generated documentation for ${subdir}' -m '${env.BUILD_TAG} ${commit}'
+              """
+              gitPush(gitScm: ghp, targetBranch: 'master', targetRepo: 'origin')
+            }
+            /* Update packaging repo submodule */
+            if (release) {
+              dir("$WORKSPACE_TMP/packaging") {
+                try {
+                  def pkg = scmGit(branches: [[name: "refs/heads/${env.BRANCH_NAME}"]],
+                    userRemoteConfigs: [[credentialsId: 'github-jenkins', url: 'https://github.com/TRIQS/packaging.git']])
+                  checkout scm: pkg, changelog: false
+                  sh """#!/bin/bash -ex
+                    dir="$projectName"
+                    [[ -d triqs_\$dir ]] && dir=triqs_\$dir || [[ -d \$dir ]]
+                    echo "160000 commit ${commit}\t\$dir" | git update-index --index-info
+                    GIT_COMMITTER_EMAIL="jenkins@flatironinstitute.org" GIT_COMMITTER_NAME="Flatiron Jenkins" git commit --author='Flatiron Jenkins <jenkins@flatironinstitute.org>' -m 'Autoupdate $projectName' -m '${env.BUILD_TAG}'
+                  """
+                  gitPush(gitScm: pkg, targetBranch: env.BRANCH_NAME, targetRepo: 'origin')
+                } catch (err) {
+                  /* Ignore, non-critical -- might not exist on this branch */
+                  echo "Failed to update packaging repo"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+emailFailure()


### PR DESCRIPTION
This follows https://github.com/TRIQS/triqs/pull/1013 to update Jenkins to build on the new system.

The Dockerfile is no longer strictly necessary, except for applications that need to install additional dependencies. The image prep code could be simplified greatly without this and the build sped up.

The `PYTHONPATH` setting to point to triqsDir is new and a little messy.