### PR TITLE
[ghactions] Bump macOS gcc to g++-16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           - { os: ubuntu-24.04, cxx: clang++-20, clang_cxx: clang++-20 }
           - { os: ubuntu-24.04, cxx: g++-14, clang_cxx: clang++-20 }
           - { os: macos-15, cxx: clang++, clang_cxx: clang++ }
-          - { os: macos-15, cxx: g++-15, clang_cxx: clang++ }
+          - { os: macos-15, cxx: g++-16, clang_cxx: clang++ }
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Homebrew's default gcc formula now installs GCC 16.1.0 and we are installing it via (line 99): 
```
brew install ccache gcc llvm libomp boost fftw hdf5 open-mpi openblas
```
which provides g++-16 rather than g++-15 now. The macOS gcc matrix entry hardcoded g++-15, so 'brew install gcc' left no g++-15 in PATH and CMake failed to find the compiler. Bump the matrix to g++-16 to match the brew default. Other option would be to fix the version in `brew install` , but I think we never did that. 

I already did this bump in dfttools and dftkit without issues (these rebuild triqs with this new gcc 16 compiler): 
- https://github.com/TRIQS/dft_tools/actions/runs/27809828067/job/82297412051
- https://github.com/TRIQS/dftkit/actions/runs/27809779813/job/82297263970

but left all other repos untouched. 